### PR TITLE
MB-2651 Add TOC links to the repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # Prime API
 
-The documentation can be found in our [wiki](https://github.com/transcom/prime_api_deliverable/wiki)
+Read the documentation in the Prime API [Wiki](https://github.com/transcom/prime_api_deliverable/wiki), available in this repo.
+
+## Quick Links
+
+* [Home](https://github.com/transcom/prime_api_deliverable/wiki)
+* [Getting Started](https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started)
+  * [Install Dependencies](https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#install-dependencies)
+  * [Checkout Project](https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#checkout-project)
+  * [Local Environment Variables](https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#local-env-variables)
+    * [Generate Key](https://github.com/transcom/prime_api_deliverable/wiki/Local-Env:-Generate-Key)
+  * [Prime Docker](https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-docker)
+  * [First API Call](https://github.com/transcom/prime_api_deliverable/wiki/Getting-Started#run-prime-api-client)
+  * [Sample Java Client](https://github.com/transcom/prime_api_deliverable/wiki/Sample-Java-Client)
+* [Authentication](https://github.com/transcom/prime_api_deliverable/wiki/Authentication)
+  * [Mutual TLS](https://github.com/transcom/prime_api_deliverable/wiki/Authentication#mutual-tls)
+  * [Using Postman + mTLS](https://github.com/transcom/prime_api_deliverable/wiki/Authentication#set-up-postman-for-mutual-tls)
+* [API Endpoints](https://github.com/transcom/prime_api_deliverable/wiki/API-Endpoints)
+  * [About](https://github.com/transcom/prime_api_deliverable/wiki/API-Endpoints#about)
+  * [Documentation](https://github.com/transcom/prime_api_deliverable/wiki/API-Endpoints#documentation-using-redoc)
+  * [Prime API Client](https://github.com/transcom/prime_api_deliverable/wiki/Prime-API-Client)
+  * [Postman](https://github.com/transcom/prime_api_deliverable/wiki/Using-Postman)
+* [Glossary](https://github.com/transcom/prime_api_deliverable/wiki/Glossary)
+* [Sequence Diagram](https://github.com/transcom/prime_api_deliverable/wiki/Sequence-Diagram)


### PR DESCRIPTION
## Background
Sandy and I discussed where to place the new documentation for the sample java client, and decided keeping it in the wiki was best for consistency and easy access.

We also discussed adding a link to the new Sample Java Client page to make it easier to find. Imagine you've landed on the repo and see a sample java client directory. Because that directory has its own auto-generated readme, people may not realize there is additional documentation we've written in the wiki.

I started updating the readme to include this additional link, and realized it may be easier and more helpful to include the rest of the sidebar links from the wiki. It's easy to maintain, and provides a high visibility access point to the docs.

## Description
* This PR includes a proposed update to the readme, which includes the complete wiki sidebar copied over. 

## Reviewer Notes
Let me know if you have any concerns about including these links in the readme, or have a different suggested approach. 

